### PR TITLE
Add PyLav tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
       packages: write
     env:
       TITLE: Red-DiscordBot
-      GHCR_SLUG: ghcr.io/phasecorex/red-discordbot
-      DOCK_SLUG: docker.io/phasecorex/red-discordbot
+      GHCR_SLUG: ghcr.io/Drapersniper/red-discordbot
+      DOCK_SLUG: docker.io/Drapersniper/red-discordbot
     steps:
       -
         name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,8 +208,8 @@ jobs:
             PCX_DISCORDBOT_COMMIT=${{ github.sha }}
           cache-from: |
             ${{ env.GHCR_SLUG }}:extra-audio
-            ${{ env.GHCR_SLUG }}:core-pylav
-            ${{ env.GHCR_SLUG }}:extra-pylav
+            ${{ env.GHCR_SLUG }}:pylav-core
+            ${{ env.GHCR_SLUG }}:pylav-extra
           labels: ${{ steps.meta.outputs.labels }}
       -
         name: Check manifest
@@ -219,14 +219,14 @@ jobs:
           docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:extra
           docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:core-audio
           docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:extra-audio
-          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:extra-pylav
-          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:core-pylav
+          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:pylav-extra
+          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:pylav-core
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:core
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:extra
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:core-audio
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:extra-audio
-          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:extra-pylav
-          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:core-pylav
+          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:pylav-extra
+          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:pylav-core
       -
         name: Check pull
         if: github.event_name != 'pull_request'
@@ -235,23 +235,23 @@ jobs:
           docker pull ${{ env.GHCR_SLUG }}:extra
           docker pull ${{ env.GHCR_SLUG }}:core-audio
           docker pull ${{ env.GHCR_SLUG }}:extra-audio
-          docker pull ${{ env.GHCR_SLUG }}:core-pylav
-          docker pull ${{ env.GHCR_SLUG }}:extra-pylav
+          docker pull ${{ env.GHCR_SLUG }}:pylav-core
+          docker pull ${{ env.GHCR_SLUG }}:pylav-extra
           docker image inspect ${{ env.GHCR_SLUG }}:core
           docker image inspect ${{ env.GHCR_SLUG }}:extra
           docker image inspect ${{ env.GHCR_SLUG }}:core-audio
           docker image inspect ${{ env.GHCR_SLUG }}:extra-audio
-          docker image inspect ${{ env.GHCR_SLUG }}:core-pylav
-          docker image inspect ${{ env.GHCR_SLUG }}:extra-pylav
+          docker image inspect ${{ env.GHCR_SLUG }}:pylav-core
+          docker image inspect ${{ env.GHCR_SLUG }}:pylav-extra
           docker pull ${{ env.DOCK_SLUG }}:core
           docker pull ${{ env.DOCK_SLUG }}:extra
           docker pull ${{ env.DOCK_SLUG }}:core-audio
           docker pull ${{ env.DOCK_SLUG }}:extra-audio
-          docker pull ${{ env.DOCK_SLUG }}:core-pylav
-          docker pull ${{ env.DOCK_SLUG }}:extra-pylav
+          docker pull ${{ env.DOCK_SLUG }}:pylav-core
+          docker pull ${{ env.DOCK_SLUG }}:pylav-extra
           docker image inspect ${{ env.DOCK_SLUG }}:core
           docker image inspect ${{ env.DOCK_SLUG }}:extra
           docker image inspect ${{ env.DOCK_SLUG }}:core-audio
           docker image inspect ${{ env.DOCK_SLUG }}:extra-audio
-          docker image inspect ${{ env.DOCK_SLUG }}:core-pylav
-          docker image inspect ${{ env.DOCK_SLUG }}:extra-pylav
+          docker image inspect ${{ env.DOCK_SLUG }}:pylav-core
+          docker image inspect ${{ env.DOCK_SLUG }}:pylav-extra

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
   repository_dispatch:
     types:
       - upstream_image_update
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,9 +171,7 @@ jobs:
           target: core-pylav
           platforms: |
             linux/amd64
-            linux/arm/v7
             linux/arm64
-            linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.GHCR_SLUG }}:extra

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,6 @@ jobs:
             linux/amd64
             linux/arm/v7
             linux/arm64
-            linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.GHCR_SLUG }}:full-pylav

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
       packages: write
     env:
       TITLE: Red-DiscordBot
-      GHCR_SLUG: ghcr.io/Drapersniper/red-discordbot
-      DOCK_SLUG: docker.io/Drapersniper/red-discordbot
+      GHCR_SLUG: ghcr.io/drapersniper/red-discordbot
+      DOCK_SLUG: docker.io/drapersniper/red-discordbot
     steps:
       -
         name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,9 @@ jobs:
           build-args: |
             PCX_DISCORDBOT_BUILD=${{ github.run_id }}
             PCX_DISCORDBOT_COMMIT=${{ github.sha }}
-          cache-from: |
+          cache-from: type=gha
+          cache-to: |  
+            type=gha,mode=max
             ${{ env.GHCR_SLUG }}:extra-audio
           labels: ${{ steps.meta.outputs.labels }}
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
           target: core-pylav
           platforms: |
             linux/amd64
+            linux/arm/v7
             linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
             PCX_DISCORDBOT_BUILD=${{ github.run_id }}
             PCX_DISCORDBOT_COMMIT=${{ github.sha }}
           cache-from: |
-            ${{ env.GHCR_SLUG }}:core-audio
+            ${{ env.GHCR_SLUG }}:core
             ${{ env.GHCR_SLUG }}:core-pylav
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push extra-pylav

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
       packages: write
     env:
       TITLE: Red-DiscordBot
-      GHCR_SLUG: ghcr.io/drapersniper/red-discordbot
-      DOCK_SLUG: docker.io/drapersniper/red-discordbot
+      GHCR_SLUG: ghcr.io/phasecorex/red-discordbot
+      DOCK_SLUG: docker.io/phasecorex/red-discordbot
     steps:
       -
         name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ jobs:
           target: extra-audio
           platforms: |
             linux/amd64
-            linux/arm/v7
             linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,52 @@ jobs:
             linux/amd64
             linux/arm/v7
             linux/arm64
+            linux/386
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.GHCR_SLUG }}:extra
+            ${{ env.DOCK_SLUG }}:extra
+          build-args: |
+            PCX_DISCORDBOT_BUILD=${{ github.run_id }}
+            PCX_DISCORDBOT_COMMIT=${{ github.sha }}
+          cache-from: |
+            ${{ env.GHCR_SLUG }}:extra-audio
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Build and push core-audio
+        uses: docker/build-push-action@v3
+        with:
+          target: core-audio
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+            linux/386
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.GHCR_SLUG }}:audio
+            ${{ env.DOCK_SLUG }}:audio
+            ${{ env.GHCR_SLUG }}:core-audio
+            ${{ env.DOCK_SLUG }}:core-audio
+            ${{ env.GHCR_SLUG }}:latest
+            ${{ env.DOCK_SLUG }}:latest
+          build-args: |
+            PCX_DISCORDBOT_BUILD=${{ github.run_id }}
+            PCX_DISCORDBOT_COMMIT=${{ github.sha }}
+          cache-from: |
+            ${{ env.GHCR_SLUG }}:core
+            ${{ env.GHCR_SLUG }}:core-audio
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push pylav-core
+        uses: docker/build-push-action@v3
+        with:
+          target: core-pylav
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64
+            linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.GHCR_SLUG }}:pylav

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,8 +179,8 @@ jobs:
             ${{ env.DOCK_SLUG }}:pylav
             ${{ env.GHCR_SLUG }}:core-pylav
             ${{ env.DOCK_SLUG }}:core-pylav
-            ${{ env.GHCR_SLUG }}:pylav-latest
-            ${{ env.DOCK_SLUG }}:pylav-latest
+            ${{ env.GHCR_SLUG }}:latest-pylav
+            ${{ env.DOCK_SLUG }}:latest-pylav
           build-args: |
             PCX_DISCORDBOT_BUILD=${{ github.run_id }}
             PCX_DISCORDBOT_COMMIT=${{ github.sha }}
@@ -199,8 +199,8 @@ jobs:
             linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.GHCR_SLUG }}:pylav-full
-            ${{ env.DOCK_SLUG }}:pylav-full
+            ${{ env.GHCR_SLUG }}:full-pylav
+            ${{ env.DOCK_SLUG }}:full-pylav
             ${{ env.GHCR_SLUG }}:extra-pylav
             ${{ env.DOCK_SLUG }}:extra-pylav
           build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,52 +171,8 @@ jobs:
           target: core-pylav
           platforms: |
             linux/amd64
-            linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ env.GHCR_SLUG }}:extra
-            ${{ env.DOCK_SLUG }}:extra
-          build-args: |
-            PCX_DISCORDBOT_BUILD=${{ github.run_id }}
-            PCX_DISCORDBOT_COMMIT=${{ github.sha }}
-          cache-from: |
-            ${{ env.GHCR_SLUG }}:extra-audio
-          labels: ${{ steps.meta.outputs.labels }}
-      -
-        name: Build and push core-audio
-        uses: docker/build-push-action@v3
-        with:
-          target: core-audio
-          platforms: |
-            linux/amd64
             linux/arm/v7
             linux/arm64
-            linux/386
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ env.GHCR_SLUG }}:audio
-            ${{ env.DOCK_SLUG }}:audio
-            ${{ env.GHCR_SLUG }}:core-audio
-            ${{ env.DOCK_SLUG }}:core-audio
-            ${{ env.GHCR_SLUG }}:latest
-            ${{ env.DOCK_SLUG }}:latest
-          build-args: |
-            PCX_DISCORDBOT_BUILD=${{ github.run_id }}
-            PCX_DISCORDBOT_COMMIT=${{ github.sha }}
-          cache-from: |
-            ${{ env.GHCR_SLUG }}:core
-            ${{ env.GHCR_SLUG }}:core-audio
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push pylav-core
-        uses: docker/build-push-action@v3
-        with:
-          target: core-pylav
-          platforms: |
-            linux/amd64
-            linux/arm/v7
-            linux/arm64
-            linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.GHCR_SLUG }}:pylav
@@ -229,7 +185,7 @@ jobs:
             PCX_DISCORDBOT_BUILD=${{ github.run_id }}
             PCX_DISCORDBOT_COMMIT=${{ github.sha }}
           cache-from: |
-            ${{ env.GHCR_SLUG }}:core
+            ${{ env.GHCR_SLUG }}:core-audio
             ${{ env.GHCR_SLUG }}:core-pylav
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push extra-pylav
@@ -238,7 +194,9 @@ jobs:
           target: extra-pylav
           platforms: |
             linux/amd64
+            linux/arm/v7
             linux/arm64
+            linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.GHCR_SLUG }}:full-pylav

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,6 @@ jobs:
           target: extra-pylav
           platforms: |
             linux/amd64
-            linux/arm/v7
             linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,7 @@ jobs:
           build-args: |
             PCX_DISCORDBOT_BUILD=${{ github.run_id }}
             PCX_DISCORDBOT_COMMIT=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: |  
-            type=gha,mode=max
+          cache-from: |
             ${{ env.GHCR_SLUG }}:extra-audio
           labels: ${{ steps.meta.outputs.labels }}
       -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,6 @@ jobs:
             linux/amd64
             linux/arm/v7
             linux/arm64
-            linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.GHCR_SLUG }}:pylav

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,6 @@ jobs:
           target: core-pylav
           platforms: |
             linux/amd64
-            linux/arm/v7
             linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,6 @@ jobs:
             linux/amd64
             linux/arm/v7
             linux/arm64
-            linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ env.GHCR_SLUG }}:full-pylav
@@ -208,8 +207,8 @@ jobs:
             PCX_DISCORDBOT_COMMIT=${{ github.sha }}
           cache-from: |
             ${{ env.GHCR_SLUG }}:extra-audio
-            ${{ env.GHCR_SLUG }}:pylav-core
-            ${{ env.GHCR_SLUG }}:pylav-extra
+            ${{ env.GHCR_SLUG }}:core-pylav
+            ${{ env.GHCR_SLUG }}:extra-pylav
           labels: ${{ steps.meta.outputs.labels }}
       -
         name: Check manifest
@@ -219,14 +218,14 @@ jobs:
           docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:extra
           docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:core-audio
           docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:extra-audio
-          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:pylav-extra
-          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:pylav-core
+          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:extra-pylav
+          docker buildx imagetools inspect ${{ env.GHCR_SLUG }}:core-pylav
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:core
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:extra
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:core-audio
           docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:extra-audio
-          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:pylav-extra
-          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:pylav-core
+          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:extra-pylav
+          docker buildx imagetools inspect ${{ env.DOCK_SLUG }}:core-pylav
       -
         name: Check pull
         if: github.event_name != 'pull_request'
@@ -235,23 +234,23 @@ jobs:
           docker pull ${{ env.GHCR_SLUG }}:extra
           docker pull ${{ env.GHCR_SLUG }}:core-audio
           docker pull ${{ env.GHCR_SLUG }}:extra-audio
-          docker pull ${{ env.GHCR_SLUG }}:pylav-core
-          docker pull ${{ env.GHCR_SLUG }}:pylav-extra
+          docker pull ${{ env.GHCR_SLUG }}:core-pylav
+          docker pull ${{ env.GHCR_SLUG }}:extra-pylav
           docker image inspect ${{ env.GHCR_SLUG }}:core
           docker image inspect ${{ env.GHCR_SLUG }}:extra
           docker image inspect ${{ env.GHCR_SLUG }}:core-audio
           docker image inspect ${{ env.GHCR_SLUG }}:extra-audio
-          docker image inspect ${{ env.GHCR_SLUG }}:pylav-core
-          docker image inspect ${{ env.GHCR_SLUG }}:pylav-extra
+          docker image inspect ${{ env.GHCR_SLUG }}:core-pylav
+          docker image inspect ${{ env.GHCR_SLUG }}:extra-pylav
           docker pull ${{ env.DOCK_SLUG }}:core
           docker pull ${{ env.DOCK_SLUG }}:extra
           docker pull ${{ env.DOCK_SLUG }}:core-audio
           docker pull ${{ env.DOCK_SLUG }}:extra-audio
-          docker pull ${{ env.DOCK_SLUG }}:pylav-core
-          docker pull ${{ env.DOCK_SLUG }}:pylav-extra
+          docker pull ${{ env.DOCK_SLUG }}:core-pylav
+          docker pull ${{ env.DOCK_SLUG }}:extra-pylav
           docker image inspect ${{ env.DOCK_SLUG }}:core
           docker image inspect ${{ env.DOCK_SLUG }}:extra
           docker image inspect ${{ env.DOCK_SLUG }}:core-audio
           docker image inspect ${{ env.DOCK_SLUG }}:extra-audio
-          docker image inspect ${{ env.DOCK_SLUG }}:pylav-core
-          docker image inspect ${{ env.DOCK_SLUG }}:pylav-extra
+          docker image inspect ${{ env.DOCK_SLUG }}:core-pylav
+          docker image inspect ${{ env.DOCK_SLUG }}:extra-pylav

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build.sh
+/test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-/build.sh
-/test.sh
+/ignore/

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as core-pylav-build
+FROM core-build as pylav-core-build
 
 RUN set -eux; \
 # Install redbot audio dependencies
@@ -169,14 +169,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM core-pylav-build as core-pylav
+FROM pylav-core-build as pylav-core
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG core-pylav
+ENV PCX_DISCORDBOT_TAG pylav-core
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 
@@ -187,7 +187,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as extra-pylav-build
+FROM extra-build as pylav-extra-build
 
 RUN set -eux; \
 # Install redbot audio dependencies
@@ -212,14 +212,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM extra-pylav-build as extra-pylav
+FROM pylav-extra-build as pylav-extra
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG extra-pylav
+ENV PCX_DISCORDBOT_TAG pylav-extra
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ CMD ["/app/start-redbot.sh"]
 FROM core-build as core-pylav-build
 
 RUN set -eux; \
-# Install redbot audio dependencies
+# Install pylav dependencies
     apt-get update; \
     apt-get install -y --no-install-recommends \
         libaio1  \
@@ -183,7 +183,7 @@ CMD ["/app/start-redbot.sh"]
 FROM extra-build as extra-pylav-build
 
 RUN set -eux; \
-# Install redbot audio dependencies
+# Install pylav dependencies
     apt-get update; \
     apt-get install -y --no-install-recommends \
         libaio1  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as core-pylav-build
+FROM core-build as pylav-core-build
 
 RUN set -eux; \
 # Install redbot audio dependencies
@@ -157,14 +157,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM core-pylav-build as core-pylav
+FROM pylav-core-build as pylav-core
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG core-pylav
+ENV PCX_DISCORDBOT_TAG pylav-core
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 
@@ -175,7 +175,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as extra-pylav-build
+FROM extra-build as pylav-extra-build
 
 RUN set -eux; \
 # Install redbot audio dependencies
@@ -188,14 +188,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM extra-pylav-build as extra-pylav
+FROM pylav-extra-build as pylav-extra
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG extra-pylav
+ENV PCX_DISCORDBOT_TAG pylav-extra
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,10 @@ RUN set -eux; \
         # CrabRave
         ffmpeg \
         imagemagick \
-        # RSS (SciPy has no wheels for armv7)
-        $([ "$(uname --machine)" = "armv7l" ] && echo "gfortran libopenblas-dev liblapack-dev") \
+        # RSS \
+        gfortran \
+        libopenblas-dev \
+        liblapack-dev \
         # ReTrigger
         tesseract-ocr \
     ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as pylav-core-build
+FROM core-audio-build as pylav-core-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -182,7 +182,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as pylav-extra-build
+FROM audio-extra-build as pylav-extra-build
 
 RUN set -eux; \
 # Install pylav dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,8 @@ RUN set -eux; \
         # CrabRave
         ffmpeg \
         imagemagick \
-        # RSS \
-        gfortran \
-        libopenblas-dev \
-        liblapack-dev \
+        # RSS (SciPy has no wheels for armv7)
+        $([ "$(uname --machine)" = "armv7l" ] && echo "gfortran libopenblas-dev liblapack-dev") \
         # ReTrigger
         tesseract-ocr \
     ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as core-pylav-build
+FROM core-build as pylav-core-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -163,14 +163,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM core-pylav-build as core-pylav
+FROM pylav-core-build as pylav-core
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG core-pylav
+ENV PCX_DISCORDBOT_TAG pylav-core
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1
@@ -182,7 +182,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as extra-pylav-build
+FROM extra-build as pylav-extra-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -195,14 +195,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM extra-pylav-build as extra-pylav
+FROM pylav-extra-build as pylav-extra
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG extra-pylav
+ENV PCX_DISCORDBOT_TAG pylav-extra
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-audio-build as pylav-core-build
+FROM core-audio-build as core-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -163,14 +163,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-core-build as pylav-core
+FROM core-pylav-build as core-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-core
+ENV PCX_DISCORDBOT_TAG core-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1
@@ -182,7 +182,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM audio-extra-build as pylav-extra-build
+FROM extra-audio-build as extra-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -195,14 +195,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-extra-build as pylav-extra
+FROM extra-pylav-build as extra-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-extra
+ENV PCX_DISCORDBOT_TAG extra-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as pylav-core-build
+FROM core-audio-build as pylav-core-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -180,7 +180,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as pylav-extra-build
+FROM audio-extra-build as pylav-extra-build
 
 RUN set -eux; \
 # Install pylav dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-audio-build as core-pylav-build
+FROM core-build as core-pylav-build
 
 RUN set -eux; \
 # Install redbot audio dependencies
@@ -175,7 +175,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-audio-build as extra-pylav-build
+FROM extra-build as extra-pylav-build
 
 RUN set -eux; \
 # Install redbot audio dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as pylav-core-build
+FROM core-audio-build as core-pylav-build
 
 RUN set -eux; \
 # Install redbot audio dependencies
@@ -152,31 +152,19 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         libaio1  \
         libaio-dev \
-        gnupg \
-        ca-certificates \
-        curl \
     ; \
-    # Users should be using a docker container ghcr.io/drapersniper/pylav-node:master instead of a manage node
-    #  But not all users will be aware of this to lets install java for them
-    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg; \
-    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        zulu19-ca-jdk-headless; \
     rm -rf /var/lib/apt/lists/*; \
-    rm /etc/apt/sources.list.d/zulu.list; \
-    rm /usr/share/keyrings/azul.gpg; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-core-build as pylav-core
+FROM core-pylav-build as core-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-core
+ENV PCX_DISCORDBOT_TAG core-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 
@@ -187,7 +175,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as pylav-extra-build
+FROM extra-audio-build as extra-pylav-build
 
 RUN set -eux; \
 # Install redbot audio dependencies
@@ -195,31 +183,19 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
         libaio1  \
         libaio-dev \
-        gnupg \
-        ca-certificates \
-        curl \
     ; \
-    # Users should be using a docker container ghcr.io/drapersniper/pylav-node:master instead of a manage node
-    #  But not all users will be aware of this to lets install java for them
-    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg; \
-    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        zulu19-ca-jdk-headless; \
     rm -rf /var/lib/apt/lists/*; \
-    rm /etc/apt/sources.list.d/zulu.list; \
-    rm /usr/share/keyrings/azul.gpg; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-extra-build as pylav-extra
+FROM extra-pylav-build as extra-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-extra
+ENV PCX_DISCORDBOT_TAG extra-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-audio-build as pylav-core-build
+FROM core-audio-build as core-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -161,14 +161,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-core-build as pylav-core
+FROM core-pylav-build as core-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-core
+ENV PCX_DISCORDBOT_TAG core-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1
@@ -180,7 +180,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM audio-extra-build as pylav-extra-build
+FROM extra-audio-build as extra-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -193,14 +193,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-extra-build as pylav-extra
+FROM extra-pylav-build as extra-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-extra
+ENV PCX_DISCORDBOT_TAG extra-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-audio-build as core-pylav-build
+FROM core-build as core-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -180,7 +180,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-audio-build as extra-pylav-build
+FROM extra-build as extra-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,8 @@ RUN set -eux; \
         # CrabRave
         ffmpeg \
         imagemagick \
-        # RSS \
-        gfortran \
-        libopenblas-dev \
-        liblapack-dev \
+        # RSS (SciPy has no wheels for armv7)
+        $([ "$(uname --machine)" = "armv7l" ] && echo "gfortran libopenblas-dev liblapack-dev") \
         # ReTrigger
         tesseract-ocr \
     ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,10 @@ RUN set -eux; \
         # CrabRave
         ffmpeg \
         imagemagick \
-        # RSS (SciPy has no wheels for armv7)
-        $([ "$(uname --machine)" = "armv7l" ] && echo "gfortran libopenblas-dev liblapack-dev") \
+        # RSS \
+        gfortran \
+        libopenblas-dev \
+        liblapack-dev \
         # ReTrigger
         tesseract-ocr \
     ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,8 @@ RUN set -eux; \
         # CrabRave
         ffmpeg \
         imagemagick \
-        # RSS \
-        gfortran \
-        libopenblas-dev \
-        liblapack-dev \
+        # RSS (SciPy has no wheels for armv7)
+        $([ "$(uname --machine)" = "armv7l" ] && echo "gfortran libopenblas-dev liblapack-dev") \
         # ReTrigger
         tesseract-ocr \
     ; \
@@ -150,7 +148,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-audio-build as core-pylav-build
+FROM core-build as core-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -182,7 +180,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-audio-build as extra-pylav-build
+FROM extra-build as extra-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG core
+ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -82,6 +83,7 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG extra
+ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -109,6 +111,7 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG core-audio
+ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -136,6 +139,7 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG extra-audio
+ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -144,10 +148,10 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as pylav-core-build
+FROM core-build as core-pylav-build
 
 RUN set -eux; \
-# Install redbot audio dependencies
+# Install pylav dependencies
     apt-get update; \
     apt-get install -y --no-install-recommends \
         libaio1  \
@@ -157,16 +161,17 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-core-build as pylav-core
+FROM core-pylav-build as core-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-core
+ENV PCX_DISCORDBOT_TAG core-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
+ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -175,10 +180,10 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as pylav-extra-build
+FROM extra-build as extra-pylav-build
 
 RUN set -eux; \
-# Install redbot audio dependencies
+# Install pylav dependencies
     apt-get update; \
     apt-get install -y --no-install-recommends \
         libaio1  \
@@ -188,16 +193,17 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM pylav-extra-build as pylav-extra
+FROM extra-pylav-build as extra-pylav
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG pylav-extra
+ENV PCX_DISCORDBOT_TAG extra-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
+ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-audio-build as core-pylav-build
+FROM core-build as core-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -182,7 +182,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-audio-build as extra-pylav-build
+FROM extra-build as extra-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG core
-ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -83,7 +82,6 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG extra
-ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -111,7 +109,6 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG core-audio
-ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -139,7 +136,6 @@ ARG PCX_DISCORDBOT_COMMIT
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG extra-audio
-ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -151,13 +147,25 @@ CMD ["/app/start-redbot.sh"]
 FROM core-build as core-pylav-build
 
 RUN set -eux; \
-# Install pylav dependencies
+# Install redbot audio dependencies
     apt-get update; \
     apt-get install -y --no-install-recommends \
         libaio1  \
         libaio-dev \
+        gnupg \
+        ca-certificates \
+        curl \
     ; \
+    # Users should be using a docker container ghcr.io/drapersniper/pylav-node:master instead of a manage node
+    #  But not all users will be aware of this to lets install java for them
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        zulu19-ca-jdk-headless; \
     rm -rf /var/lib/apt/lists/*; \
+    rm /etc/apt/sources.list.d/zulu.list; \
+    rm /usr/share/keyrings/azul.gpg; \
     mkdir -p /data/pylav;
 
 
@@ -171,7 +179,6 @@ ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG core-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
-ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 
@@ -183,13 +190,25 @@ CMD ["/app/start-redbot.sh"]
 FROM extra-build as extra-pylav-build
 
 RUN set -eux; \
-# Install pylav dependencies
+# Install redbot audio dependencies
     apt-get update; \
     apt-get install -y --no-install-recommends \
         libaio1  \
         libaio-dev \
+        gnupg \
+        ca-certificates \
+        curl \
     ; \
+    # Users should be using a docker container ghcr.io/drapersniper/pylav-node:master instead of a manage node
+    #  But not all users will be aware of this to lets install java for them
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        zulu19-ca-jdk-headless; \
     rm -rf /var/lib/apt/lists/*; \
+    rm /etc/apt/sources.list.d/zulu.list; \
+    rm /usr/share/keyrings/azul.gpg; \
     mkdir -p /data/pylav;
 
 
@@ -203,7 +222,6 @@ ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
 ENV PCX_DISCORDBOT_TAG extra-pylav
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
-ENV PYLAV__IN_CONTAINER 1
 
 COPY root/ /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as core-pylav-build
+FROM core-build as pylav-core-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -161,14 +161,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM core-pylav-build as core-pylav
+FROM pylav-core-build as pylav-core
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG core-pylav
+ENV PCX_DISCORDBOT_TAG pylav-core
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1
@@ -180,7 +180,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as extra-pylav-build
+FROM extra-build as pylav-extra-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -193,14 +193,14 @@ RUN set -eux; \
     mkdir -p /data/pylav;
 
 
-FROM extra-pylav-build as extra-pylav
+FROM pylav-extra-build as pylav-extra
 
 ARG PCX_DISCORDBOT_BUILD
 ARG PCX_DISCORDBOT_COMMIT
 
 ENV PCX_DISCORDBOT_BUILD ${PCX_DISCORDBOT_BUILD}
 ENV PCX_DISCORDBOT_COMMIT ${PCX_DISCORDBOT_COMMIT}
-ENV PCX_DISCORDBOT_TAG extra-pylav
+ENV PCX_DISCORDBOT_TAG pylav-extra
 ENV PYLAV__DATA_FOLDER /data/pylav
 ENV PYLAV__YAML_CONFIG /data/pylav/pylav.yaml
 ENV PYLAV__IN_CONTAINER 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,10 @@ RUN set -eux; \
         # CrabRave
         ffmpeg \
         imagemagick \
-        # RSS (SciPy has no wheels for armv7)
-        $([ "$(uname --machine)" = "armv7l" ] && echo "gfortran libopenblas-dev liblapack-dev") \
+        # RSS \
+        gfortran \
+        libopenblas-dev \
+        liblapack-dev \
         # ReTrigger
         tesseract-ocr \
     ; \
@@ -148,7 +150,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM core-build as core-pylav-build
+FROM core-audio-build as core-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies
@@ -180,7 +182,7 @@ CMD ["/app/start-redbot.sh"]
 
 #######################################################################################
 
-FROM extra-build as extra-pylav-build
+FROM extra-audio-build as extra-pylav-build
 
 RUN set -eux; \
 # Install pylav dependencies

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Same as extra, but with Java included so that you can use the Audio cog.
 Basically, pick if you want bare minimum (core) or extra 3rd party cog support (extra), then add the "-audio" to the tag if you want the Audio cog to work.
 
 
-### core-pylav (Alias: pylav, pylav-latest)
+### core-pylav (Alias: pylav, latest-pylav)
 Same as core, but it adds the [PyLav cogs](https://github.com/PyLav/Red-Cogs) to the bot for users using the JSON driver.
 
 > **Note**
@@ -257,7 +257,7 @@ Make sure to read [pylav.yaml Setup (Docker)](https://github.com/PyLav/PyLav/blo
 > PyLav requires adittional configuration not covered here, make sure to follow the instructions in its SETUP documentation.
 
 
-### extra-pylav (Alias: pylav-full)
+### extra-pylav (Alias: full-pylav)
 Same as extra, but it adds the [PyLav cogs](https://github.com/PyLav/Red-Cogs) to the bot for users using the JSON driver.
 
 > **Note**

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -46,13 +46,13 @@ def create_or_update_repo_manager_setting() -> None:
     if not RepoManagerSetting.exists():
         log.info("Creating RepoManager setting")
         with RepoManagerSetting.open("w", encoding="utf-8") as f:
-            json.dump({"170708480": {"GLOBAL": {"repos": {"pylav": "master"}}}}, f)
+            json.dump({"170708480": {"GLOBAL": {"repos": {"pylav": "develop"}}}}, f)
     else:
         log.info("Updating RepoManager setting")
         with RepoManagerSetting.open("r", encoding="utf-8") as f:
             exiting_data = json.load(f)
         if "pylav" not in exiting_data["170708480"]["GLOBAL"]["repos"]:
-            exiting_data["170708480"]["GLOBAL"]["repos"]["pylav"] = "master"
+            exiting_data["170708480"]["GLOBAL"]["repos"]["pylav"] = "develop"
             with RepoManagerSetting.open("w", encoding="utf-8") as f:
                 json.dump(exiting_data, f)
 

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -174,8 +174,6 @@ def install_requirements(
                 "--require-virtualenv",
                 "--upgrade-strategy",
                 "eager",
-                "--target",
-                DownloaderLibFolder,
                 "--editable",
                 ".[all]",
             ],

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -103,7 +103,10 @@ def get_pylav_cogs() -> Dict[str, pathlib.Path]:
 
 def copy_and_overwrite(from_path: Union[str, os.PathLike[str]], to_path: Union[str, os.PathLike[str]], symlink: bool = False) -> None:
     if os.path.exists(to_path):
-        shutil.rmtree(to_path)
+        if not os.path.islink(to_path):
+            shutil.rmtree(to_path)
+        else:
+            os.unlink(to_path)
     if symlink:
         log.info("Symlinking %s to %s", from_path, to_path)
         os.symlink(from_path, to_path)

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -76,7 +76,7 @@ def clone_or_update_pylav_repo() -> str:
         log.info("Updating PyLav repo")
         subprocess.call(["git", "reset", "--hard", "HEAD", "-q"], cwd=RepoManagerRepoFolder, env=env)
         subprocess.call(["git", "clean", "-f", "-d", "-q"], cwd=RepoManagerRepoFolder, env=env)
-        subprocess.call(["git", "pull", "-q"], cwd=RepoManagerRepoFolder, env=env)
+        subprocess.call(["git", "pull", "-q", "--rebase", "--autostash"], cwd=RepoManagerRepoFolder, env=env)
     else:
         log.info("Cloning PyLav repo")
         subprocess.call(["git", "clone", CogRepoURL, RepoManagerRepoFolder], cwd=RepoManagerRepoFolder, env=env)

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -23,6 +23,7 @@ log = logging.getLogger("PyLavSetup")
 
 DEV_PYLAV = os.environ.get("PYLAV__DEV_LIB")
 DEV_PYLAV_COGS = os.environ.get("PYLAV__DEV_COG")
+DEV_BRANCH = os.environ.get("PYLAV__DEV_BRANCH", "develop")
 
 
 with pathlib.Path("/data/config.json").open("r", encoding="utf-8") as __f:
@@ -46,13 +47,13 @@ def create_or_update_repo_manager_setting() -> None:
     if not RepoManagerSetting.exists():
         log.info("Creating RepoManager setting")
         with RepoManagerSetting.open("w", encoding="utf-8") as f:
-            json.dump({"170708480": {"GLOBAL": {"repos": {"pylav": "develop"}}}}, f)
+            json.dump({"170708480": {"GLOBAL": {"repos": {"pylav": DEV_BRANCH}}}}, f)
     else:
         log.info("Updating RepoManager setting")
         with RepoManagerSetting.open("r", encoding="utf-8") as f:
             exiting_data = json.load(f)
         if "pylav" not in exiting_data["170708480"]["GLOBAL"]["repos"]:
-            exiting_data["170708480"]["GLOBAL"]["repos"]["pylav"] = "develop"
+            exiting_data["170708480"]["GLOBAL"]["repos"]["pylav"] = DEV_BRANCH
             with RepoManagerSetting.open("w", encoding="utf-8") as f:
                 json.dump(exiting_data, f)
 
@@ -77,10 +78,13 @@ def clone_or_update_pylav_repo() -> str:
         log.info("Updating PyLav repo")
         subprocess.call(["git", "reset", "--hard", "HEAD", "-q"], cwd=RepoManagerRepoFolder, env=env)
         subprocess.call(["git", "clean", "-f", "-d", "-q"], cwd=RepoManagerRepoFolder, env=env)
+        subprocess.call(["git", "checkout", DEV_BRANCH], cwd=RepoManagerRepoFolder, env=env)
         subprocess.call(["git", "pull", "-q", "--rebase", "--autostash"], cwd=RepoManagerRepoFolder, env=env)
+
     else:
         log.info("Cloning PyLav repo")
         subprocess.call(["git", "clone", CogRepoURL, RepoManagerRepoFolder], cwd=RepoManagerRepoFolder, env=env)
+        subprocess.call(["git", "checkout", DEV_BRANCH], cwd=RepoManagerRepoFolder, env=env)
     return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=RepoManagerRepoFolder, env=env).decode().strip()
 
 

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -26,7 +26,7 @@ if not STORAGE_TYPE:
     STORAGE_TYPE = _data["docker"]["STORAGE_TYPE"]
 
 
-IS_JSON = STORAGE_TYPE == "json"
+IS_JSON = STORAGE_TYPE.upper() == "JSON"
 
 if not IS_JSON:
     RepoManagerRepoFolder = pathlib.Path("/data/pylav/cogs")

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -19,6 +19,18 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)5s: %(me
 
 log = logging.getLogger("PyLavSetup")
 
+STORAGE_TYPE = os.environ.get("STORAGE_TYPE")
+
+if not STORAGE_TYPE:
+    _data = json.load(pathlib.Path("/data/config.json").open("r", encoding="utf-8"))
+    STORAGE_TYPE = _data["docker"]["STORAGE_TYPE"]
+
+
+IS_JSON = STORAGE_TYPE == "json"
+
+if not IS_JSON:
+    RepoManagerRepoFolder = pathlib.Path("/data/pylav/cogs")
+
 
 def get_git_env() -> Dict[str, str]:
     env = os.environ.copy()
@@ -157,14 +169,16 @@ if __name__ == "__main__":
         log.info("PyLav is up to date")
         sys.exit(0)
     else:
-        install_or_update_pylav_cogs(cogs_mapping)
+        if IS_JSON:
+            install_or_update_pylav_cogs(cogs_mapping)
         process = install_requirements(cogs_mapping)
     try:
         log.info("Current PyLav-Cogs Commit: %s", current_commit)
         downloader_data = generate_updated_downloader_setting(cogs_mapping, current_commit)
         log.info("Updated Downloader Data: %s", downloader_data)
-        create_or_update_downloader_setting(downloader_data)
-        create_or_update_repo_manager_setting()
+        if IS_JSON:
+            create_or_update_downloader_setting(downloader_data)
+            create_or_update_repo_manager_setting()
         update_existing_commit(current_commit)
         if process is not None:
             log.info("Waiting for requirements to finish installing")

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -20,15 +20,12 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)5s: %(me
 
 log = logging.getLogger("PyLavSetup")
 
-
 DEV_PYLAV = os.environ.get("PYLAV__DEV_LIB")
 DEV_PYLAV_COGS = os.environ.get("PYLAV__DEV_COG")
 DEV_BRANCH = os.environ.get("PYLAV__DEV_BRANCH", "develop")
 
-
 with pathlib.Path("/data/config.json").open("r", encoding="utf-8") as __f:
     IS_JSON = json.load(__f)["docker"]["STORAGE_TYPE"].upper() == "JSON"
-
 
 if not IS_JSON:
     RepoManagerRepoFolder = DATA_FOLDER / "git-cogs"
@@ -89,7 +86,6 @@ def clone_or_update_pylav_repo() -> str:
 
 
 def get_pylav_cogs() -> Dict[str, pathlib.Path]:
-
     return (
         {
             cog.name: cog
@@ -105,7 +101,8 @@ def get_pylav_cogs() -> Dict[str, pathlib.Path]:
     )
 
 
-def copy_and_overwrite(from_path: Union[str, os.PathLike[str]], to_path: Union[str, os.PathLike[str]], symlink: bool = False) -> None:
+def copy_and_overwrite(from_path: Union[str, os.PathLike[str]], to_path: Union[str, os.PathLike[str]],
+                       symlink: bool = False) -> None:
     if os.path.exists(to_path):
         if not os.path.islink(to_path):
             shutil.rmtree(to_path)
@@ -139,7 +136,7 @@ def get_requirements_for_all_cogs(cogs: Dict[str, pathlib.Path]) -> Set[str]:
 
 
 def install_requirements(
-    cogs: Dict[str, pathlib.Path]
+        cogs: Dict[str, pathlib.Path]
 ) -> tuple[
     subprocess.Popen[str] | subprocess.Popen[str | bytes | Any] | None,
     subprocess.Popen[str] | subprocess.Popen[str | bytes | Any] | None,
@@ -150,7 +147,7 @@ def install_requirements(
         log.info("Installing requirements: %s", requirements)
         proc = subprocess.Popen(
             [
-               sys.executable,
+                sys.executable,
                 "-m",
                 "pip",
                 "install",
@@ -210,7 +207,7 @@ def install_requirements(
 
 
 def generate_updated_downloader_setting(
-    cogs: Dict[str, pathlib.Path], commit_hash: str
+        cogs: Dict[str, pathlib.Path], commit_hash: str
 ) -> Dict[str, Dict[str, Union[str, bool]]]:
     return {
         cog.name: {

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -13,7 +13,8 @@ DownloaderLibFolder = pathlib.Path("/data/cogs/Downloader/lib")
 RepoManagerRepoFolder = pathlib.Path("/data/cogs/RepoManager/repos/pylav")
 CogManagerCogFolder = pathlib.Path("/data/cogs/CogManager/cogs")
 CogRepoURL = "https://github.com/PyLav/Red-Cogs"
-PyLavHashFile = pathlib.Path("/pylav/.hashfile")
+DATA_FOLDER = pathlib.Path(os.environ.get("PYLAV__DATA_FOLDER", "/pylav"))
+PyLavHashFile = DATA_FOLDER / ".hashfile"
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)5s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
@@ -29,7 +30,7 @@ with pathlib.Path("/data/config.json").open("r", encoding="utf-8") as __f:
 
 
 if not IS_JSON:
-    RepoManagerRepoFolder = pathlib.Path("/pylav/git-cogs")
+    RepoManagerRepoFolder = DATA_FOLDER / "git-cogs"
 
 
 def get_git_env() -> Dict[str, str]:

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -100,16 +100,20 @@ def get_pylav_cogs() -> Dict[str, pathlib.Path]:
     )
 
 
-def copy_and_overwrite(from_path: Union[str, os.PathLike[str]], to_path: Union[str, os.PathLike[str]]) -> None:
+def copy_and_overwrite(from_path: Union[str, os.PathLike[str]], to_path: Union[str, os.PathLike[str]], symlink: bool = False) -> None:
     if os.path.exists(to_path):
         shutil.rmtree(to_path)
-    log.info("Copying %s to %s", from_path, to_path)
-    shutil.copytree(from_path, to_path)
+    if symlink:
+        log.info("Symlinking %s to %s", from_path, to_path)
+        os.symlink(from_path, to_path)
+    else:
+        log.info("Copying %s to %s", from_path, to_path)
+        shutil.copytree(from_path, to_path)
 
 
-def install_or_update_pylav_cogs(cogs: Dict[str, pathlib.Path]) -> None:
+def install_or_update_pylav_cogs(cogs: Dict[str, pathlib.Path], symlink: bool = False) -> None:
     for cog in cogs.values():
-        copy_and_overwrite(cog, CogManagerCogFolder / cog.name)
+        copy_and_overwrite(cog, CogManagerCogFolder / cog.name, symlink=symlink)
 
 
 def get_requirements_for_all_cogs(cogs: Dict[str, pathlib.Path]) -> Set[str]:
@@ -238,7 +242,7 @@ if __name__ == "__main__":
         log.info("PyLav is up to date")
         sys.exit(0)
     else:
-        install_or_update_pylav_cogs(cogs_mapping)
+        install_or_update_pylav_cogs(cogs_mapping, symlink=True)
         process, process2 = install_requirements(cogs_mapping)
     try:
         log.info("Current PyLav-Cogs Commit: %s", current_commit)

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -150,12 +150,15 @@ def install_requirements(
         log.info("Installing requirements: %s", requirements)
         proc = subprocess.Popen(
             [
-                "/data/venv/bin/pip",
+               sys.executable,
+                "-m",
+                "pip",
                 "install",
                 "--upgrade",
                 "--no-input",
                 "--no-warn-conflicts",
                 "--require-virtualenv",
+                "--no-cache-dir",
                 "--upgrade-strategy",
                 "eager",
                 "--target",
@@ -178,12 +181,15 @@ def install_requirements(
         log.info("Installing editable PyLav")
         proc2 = subprocess.Popen(
             [
-                "/data/venv/bin/pip",
+                sys.executable,
+                "-m",
+                "pip",
                 "install",
                 "--upgrade",
                 "--no-input",
                 "--no-warn-conflicts",
                 "--require-virtualenv",
+                "--no-cache-dir",
                 "--upgrade-strategy",
                 "eager",
                 "--editable",

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -22,8 +22,8 @@ log = logging.getLogger("PyLavSetup")
 STORAGE_TYPE = os.environ.get("STORAGE_TYPE")
 
 if not STORAGE_TYPE:
-    _data = json.load(pathlib.Path("/data/config.json").open("r", encoding="utf-8"))
-    STORAGE_TYPE = _data["docker"]["STORAGE_TYPE"]
+    with pathlib.Path("/data/config.json").open("r", encoding="utf-8") as __f:
+        STORAGE_TYPE = json.load(__f)["docker"]["STORAGE_TYPE"]
 
 
 IS_JSON = STORAGE_TYPE.upper() == "JSON"

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -161,8 +161,6 @@ def install_requirements(
                 "--no-cache-dir",
                 "--upgrade-strategy",
                 "eager",
-                "--target",
-                DownloaderLibFolder,
                 *requirements,
             ],
             env=get_git_env(),

--- a/root/app/functions/pylav_setup.py
+++ b/root/app/functions/pylav_setup.py
@@ -80,7 +80,7 @@ def clone_or_update_pylav_repo() -> str:
     else:
         log.info("Cloning PyLav repo")
         subprocess.call(["git", "clone", CogRepoURL, RepoManagerRepoFolder], cwd=RepoManagerRepoFolder, env=env)
-    return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=RepoManagerRepoFolder, env=env).decode().strip()
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=RepoManagerRepoFolder, env=env).decode().strip()
 
 
 def get_pylav_cogs() -> Dict[str, pathlib.Path]:
@@ -118,7 +118,24 @@ def get_requirements_for_all_cogs(cogs: Dict[str, pathlib.Path]) -> Set[str]:
 def install_requirements(cogs: Dict[str, pathlib.Path]) -> None | subprocess.Popen[str]:
     if requirements := get_requirements_for_all_cogs(cogs):
         log.info("Installing requirements: %s", requirements)
-        proc = subprocess.Popen(["/data/venv/bin/pip", "install", "--upgrade", "--no-input", "--no-warn-conflicts", "--require-virtualenv", "--upgrade-strategy", "eager", "--target",  DownloaderLibFolder, *requirements], env=get_git_env(), stdout=subprocess.PIPE, universal_newlines=True)
+        proc = subprocess.Popen(
+            [
+                "/data/venv/bin/pip",
+                "install",
+                "--upgrade",
+                "--no-input",
+                "--no-warn-conflicts",
+                "--require-virtualenv",
+                "--upgrade-strategy",
+                "eager",
+                "--target",
+                DownloaderLibFolder,
+                *requirements,
+            ],
+            env=get_git_env(),
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        )
         while True:
             line = proc.stdout.readline()
             if not line:
@@ -130,7 +147,9 @@ def install_requirements(cogs: Dict[str, pathlib.Path]) -> None | subprocess.Pop
     log.info("Requirements installed")
 
 
-def generate_updated_downloader_setting(cogs: Dict[str, pathlib.Path], commit_hash: str) -> Dict[str, Dict[str, Union[str, bool]]]:
+def generate_updated_downloader_setting(
+    cogs: Dict[str, pathlib.Path], commit_hash: str
+) -> Dict[str, Dict[str, Union[str, bool]]]:
     return {
         cog.name: {
             "repo_name": "pylav",

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -12,8 +12,11 @@ SETUPTOOLS_EXTRAS=""
 if [ "${STORAGE_TYPE}" != "json" ]; then
     SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
 fi
-# Clone/Pull/Install/Update PyLav Cogs
-python /app/functions/pylav_setup.py
+
+if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then
+  # Clone/Pull/Install/Update PyLav Cogs
+  python /app/functions/pylav_setup.py
+fi
 
 if [ -n "${CUSTOM_REDBOT_PACKAGE:-}" ]; then
     echo "WARNING: You have specified a custom Red-DiscordBot Pip install. Little to no support will be given for this setup."

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -9,7 +9,9 @@ if [ -z "${STORAGE_TYPE:-}" ]; then
     STORAGE_TYPE=$(jq -r .docker.STORAGE_TYPE /data/config.json | tr '[:upper:]' '[:lower:]')
 fi
 SETUPTOOLS_EXTRAS=""
-
+if [ "${STORAGE_TYPE}" != "json" ]; then
+    SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
+fi
 # Clone/Pull/Install/Update PyLav Cogs
 python /app/functions/pylav_setup.py
 

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -9,12 +9,9 @@ if [ -z "${STORAGE_TYPE:-}" ]; then
     STORAGE_TYPE=$(jq -r .docker.STORAGE_TYPE /data/config.json | tr '[:upper:]' '[:lower:]')
 fi
 SETUPTOOLS_EXTRAS=""
-if [ "${STORAGE_TYPE}" != "json" ]; then
-    SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
-else
-  # Install/Update PyLav for JSON configs
-  python /app/functions/pylav_setup.py
-fi
+
+# Clone/Pull/Install/Update PyLav Cogs
+python /app/functions/pylav_setup.py
 
 if [ -n "${CUSTOM_REDBOT_PACKAGE:-}" ]; then
     echo "WARNING: You have specified a custom Red-DiscordBot Pip install. Little to no support will be given for this setup."

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -9,12 +9,9 @@ if [ -z "${STORAGE_TYPE:-}" ]; then
     STORAGE_TYPE=$(jq -r .docker.STORAGE_TYPE /data/config.json | tr '[:upper:]' '[:lower:]')
 fi
 SETUPTOOLS_EXTRAS=""
-if [ "${STORAGE_TYPE}" != "json" ]; then
-    SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
-else
-  # Install/Update PyLav for JSON configs
-  python /app/functions/pylav_setup.py
-fi
+
+# Clone/Pull/Install/Update PyLav Cogs
+python /app/functions/pylav_setup.py
 
 if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then
   # Clone/Pull/Install/Update PyLav Cogs

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -14,8 +14,7 @@ if [ "${STORAGE_TYPE}" != "json" ]; then
 fi
 
 if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then
-  git git config --global --add safe.directory $PYLAV__DEV_LIB || true
-  git git config --global --add safe.directory $PYLAV__DEV_COG || true
+  git config --global --add safe.directory '*'
   python /app/functions/pylav_setup.py
 fi
 

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -11,9 +11,6 @@ fi
 SETUPTOOLS_EXTRAS=""
 if [ "${STORAGE_TYPE}" != "json" ]; then
     SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
-else
-  # Install/Update PyLav for JSON configs
-  python /app/functions/pylav_setup.py
 fi
 
 if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -11,6 +11,9 @@ fi
 SETUPTOOLS_EXTRAS=""
 if [ "${STORAGE_TYPE}" != "json" ]; then
     SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
+else
+  # Install/Update PyLav for JSON configs
+  python /app/functions/pylav_setup.py
 fi
 # Clone/Pull/Install/Update PyLav Cogs
 python /app/functions/pylav_setup.py

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -11,6 +11,9 @@ fi
 SETUPTOOLS_EXTRAS=""
 if [ "${STORAGE_TYPE}" != "json" ]; then
     SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
+else
+  # Install/Update PyLav for JSON configs
+  python /app/functions/pylav_setup.py
 fi
 
 if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -11,9 +11,6 @@ fi
 SETUPTOOLS_EXTRAS=""
 if [ "${STORAGE_TYPE}" != "json" ]; then
     SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
-else
-  # Install/Update PyLav for JSON configs
-  python /app/functions/pylav_setup.py
 fi
 # Clone/Pull/Install/Update PyLav Cogs
 python /app/functions/pylav_setup.py

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -14,12 +14,8 @@ if [ "${STORAGE_TYPE}" != "json" ]; then
 fi
 
 if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then
-  # Clone/Pull/Install/Update PyLav Cogs
-  python /app/functions/pylav_setup.py
-fi
-
-if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then
-  # Clone/Pull/Install/Update PyLav Cogs
+  git git config --global --add safe.directory $PYLAV__DEV_LIB || true
+  git git config --global --add safe.directory $PYLAV__DEV_COG || true
   python /app/functions/pylav_setup.py
 fi
 

--- a/root/app/functions/update-redbot.sh
+++ b/root/app/functions/update-redbot.sh
@@ -12,8 +12,11 @@ SETUPTOOLS_EXTRAS=""
 if [ "${STORAGE_TYPE}" != "json" ]; then
     SETUPTOOLS_EXTRAS="[${STORAGE_TYPE}]"
 fi
-# Clone/Pull/Install/Update PyLav Cogs
-python /app/functions/pylav_setup.py
+
+if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then
+  # Clone/Pull/Install/Update PyLav Cogs
+  python /app/functions/pylav_setup.py
+fi
 
 if [ -z "${PYLAV__DOCKER_DEV_SKIP_INSTALL:-}" ]; then
   # Clone/Pull/Install/Update PyLav Cogs

--- a/root/app/start-redbot.sh
+++ b/root/app/start-redbot.sh
@@ -4,6 +4,7 @@ set -euf
 # Perform mount check
 /app/functions/check-mount.sh
 
+
 # Setup environment
 . /app/functions/setup-env.sh
 


### PR DESCRIPTION
Add two tags,  `core-pylav` and `extra-pylav`; these are direct replacements for the audio tags.

Note: For PyLav to be functional, we need a Python3.11 image - so there is no need to merge this before you update the base image to 3.11, as these images wouldn't work.


Before merging this lets have a chat in discord